### PR TITLE
Added support for . seperated property names

### DIFF
--- a/src/parse-types.ts
+++ b/src/parse-types.ts
@@ -1,3 +1,4 @@
+import { getObjectProperty } from '@azlabsjs/js-object';
 import { TypeAny } from './base';
 import { createPropMapFunc } from './helpers';
 import {
@@ -96,10 +97,7 @@ export function createParseObject<T = object>(
     const _errors: { [k: string]: unknown } = {} as any;
     let hasErrors = false;
     for (const prop of propMap) {
-      if (!(prop.inputKey in value)) {
-        continue;
-      }
-      const result = tParseFn(prop._type, value[prop.inputKey]);
+      const result = tParseFn(prop._type, getObjectProperty(value, prop.inputKey));
       if (result.success) {
         _instance[prop.outputKey] = result.data;
       } else {

--- a/tests/built-type.spec.ts
+++ b/tests/built-type.spec.ts
@@ -111,7 +111,7 @@ describe('BuiltType', () => {
       },
       grades: undefined,
     });
-    
+
     expect(john.grades).toEqual([]);
     expect(john.firstName).toEqual('Peter');
     expect(john.lastName).toEqual(null);


### PR DESCRIPTION
Due to stale merging implementation for object parsing was not able to parse . seperated property mapping names. This release solve the issue by calling getObjectProperty on the value.